### PR TITLE
WDP200802-17

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-flexbox-grid": "^2.1.2",
     "react-redux": "^7.1.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.1.2",

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import { Col } from 'react-flexbox-grid';
 import styles from './NewFurniture.module.scss';
 import ProductBox from '../../common/ProductBox/ProductBox';
 
@@ -68,9 +68,9 @@ class NewFurniture extends React.Component {
           </div>
           <div className='row'>
             {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <div key={item.id} className='col-3'>
+              <Col xs={12} md={6} lg={3} key={item.id} className='col-3'>
                 <ProductBox {...item} />
-              </div>
+              </Col>
             ))}
           </div>
         </div>


### PR DESCRIPTION
- Section "New furniture" has no RWD. On tablets it should have 2-3 elements in a row, on mobiles 1-2 elements in a row.
- I`ve added "react-flexbox-grid" in package.json and used it in NewFurniture.js for changing div to Col.