### PR TITLE
WDP200802-18

### DIFF
--- a/src/components/layout/Footer/Footer.js
+++ b/src/components/layout/Footer/Footer.js
@@ -16,8 +16,8 @@ const Footer = ({ children }) => (
   <footer className={styles.root}>
     <div className={styles.footerMenu}>
       <div className='container'>
-        <div className='row'>
-          <div className='col'>
+        <div className='row col-12'>
+          <div className='col-xs-12 col-sm-6 col-md-3'>
             <div className={styles.menuWrapper}>
               <h6>Information</h6>
               <ul>
@@ -36,7 +36,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-xs-12 col-sm-6 col-md-2 col-lg-3'>
             <div className={styles.menuWrapper}>
               <h6>My account</h6>
               <ul>
@@ -55,7 +55,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-xs-12 col-sm-6 col-md-3'>
             <div className={styles.menuWrapper}>
               <h6>Information</h6>
               <ul>
@@ -74,7 +74,7 @@ const Footer = ({ children }) => (
               </ul>
             </div>
           </div>
-          <div className='col'>
+          <div className='col-xs-12 col-sm-6 col-md-4 col-lg-3'>
             <div className={styles.menuWrapper}>
               <h6>Orders</h6>
               <ul>
@@ -100,9 +100,11 @@ const Footer = ({ children }) => (
     <div className={styles.bottomBar}>
       <div className='container'>
         <div className='row align-items-center'>
-          <div className='col'></div>
+          <div className='col-sm-3 col-md-12 col-lg-3 text-center align-items-center'></div>
           <div className={'col text-center ' + styles.copyright}>
-            <p>©Copyright 2016 Bazar | All Rights Reserved</p>
+            <p className='text-sm-center text-md-left text-lg-center'>
+              ©Copyright 2016 Bazar | All Rights Reserved
+            </p>
           </div>
           <div className={'col text-right ' + styles.socialMedia}>
             <ul>


### PR DESCRIPTION
- Section "Footer" has no RWD. Higher part of the footer must be 2 sections on a row for mobiles and 1 section on a row for smaller devices. Lower part of the footer on tablets is to have Copyright on the left and socials on the right side. Empty area on the left from Copyright on tablets must be centered and 100% wide and situated above Copyright and SocialMedia.
- In Footer.js: 
  -- I`ve added classes according to text for Copyright (p element). SocialMedia are already styled on the right side, for tablets also.
  -- I`ve added classes for div situated on the left side of Copyright.
  -- I`ve added classes for divs related to higher part of the footer (for example Information).
  -- I`ve added class 'col-12' to div related to row in footerMenu.