### PR TITLE
WDP200802-15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6237,6 +6237,14 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg=="
     },
+    "flexboxgrid2": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/flexboxgrid2/-/flexboxgrid2-7.2.1.tgz",
+      "integrity": "sha512-O2bO5ZcBXnFy7cYmyt/CKb6CuwzNuUPxWJt8WOiaot8SetE9zyUahXGTSpKDm3+CTYQ5YeEMPeunMdjcxKJz4w==",
+      "requires": {
+        "normalize.css": "^7.0.0"
+      }
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -10449,6 +10457,11 @@
         "sort-keys": "^1.0.0"
       }
     },
+    "normalize.css": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-7.0.0.tgz",
+      "integrity": "sha1-q/sd2CRwZ04DIrU86xqvQSk45L8="
+    },
     "npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
@@ -12811,6 +12824,15 @@
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
+    },
+    "react-flexbox-grid": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-flexbox-grid/-/react-flexbox-grid-2.1.2.tgz",
+      "integrity": "sha512-lj1oVnIJ7TY3W6tPjFUxlUYd1DLFxEg8RiX3HAYVvreE3O9HU9n2390CFoPQ+qk1E+5MXa2t/mLMafFLAa8+7Q==",
+      "requires": {
+        "flexboxgrid2": "^7.2.0",
+        "prop-types": "^15.5.8"
+      }
     },
     "react-is": {
       "version": "16.13.1",

--- a/src/components/layout/CompanyClaim/CompanyClaim.js
+++ b/src/components/layout/CompanyClaim/CompanyClaim.js
@@ -21,13 +21,21 @@ const CompanyClaim = () => (
             <img src='/images/logo.png' alt='Bazar' />
           </a>
         </div>
-        <div className={`col text-right ${styles.cart}`}>
-          <a href='#' className={styles.cartBox}>
-            <div className={styles.cartIcon}>
-              <FontAwesomeIcon className={styles.icon} icon={faShoppingBasket} />
-            </div>
-            <div className={styles.cartCounter}>0</div>
-          </a>
+        <div className={styles.onMobiles}>
+          <div className={`col text-right ${styles.cart}`}>
+            <a href='#' className={styles.cartBox}>
+              <div className={styles.cartIcon}>
+                <FontAwesomeIcon className={styles.icon} icon={faShoppingBasket} />
+              </div>
+              <div className={styles.cartCounter}>0</div>
+            </a>
+          </div>
+          <div className={`col text-left ${styles.phoneNumberOnMobiles}`}>
+            <p>
+              <FontAwesomeIcon className={styles.icon} icon={faMobileAlt} /> 2300 - 3560
+              - 222
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -7,6 +7,10 @@
     height: 145px;
   }
 
+  .phoneNumberOnMobiles {
+    display: none;
+  }
+
   .phoneNumber {
     p {
       margin: 0;
@@ -30,6 +34,7 @@
       display: inline-block;
       position: relative;
       color: #ffffff;
+      margin-top: -28px;
 
       .cartIcon {
         background-color: $primary;
@@ -66,6 +71,41 @@
         .cartIcon {
           background-color: lighten($primary, 10%);
         }
+      }
+    }
+  }
+}
+
+@media (max-width: 767px) {
+
+  .root {
+
+    .phoneNumber {
+      display: none;
+    }
+
+    .phoneNumberOnMobiles {
+      display: block;
+      p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 42px;
+        color: rgb(216, 216, 216);
+        font-weight: 500;
+  
+        .icon {
+          font-size: 32px;
+          color: $primary;
+          vertical-align: middle;
+          margin-top: -3px;
+          margin-right: 0.8rem;
+        }
+      }
+    }
+
+    .cart {
+      .cartBox {
+        margin: 20px 8px 0 0;
       }
     }
   }

--- a/src/components/layout/TopBar/TopBar.js
+++ b/src/components/layout/TopBar/TopBar.js
@@ -33,12 +33,14 @@ const TopBar = () => (
           <ul>
             <li>
               <a href='#'>
-                <FontAwesomeIcon className={styles.icon} icon={faUser} /> Login
+                <FontAwesomeIcon className={styles.icon} icon={faUser} />
+                <a href='#'>Login</a>
               </a>
             </li>
             <li>
               <a href='#'>
-                <FontAwesomeIcon className={styles.icon} icon={faLock} /> Register
+                <FontAwesomeIcon className={styles.icon} icon={faLock} />
+                <a href='#'>Register</a>
               </a>
             </li>
             <li>

--- a/src/components/layout/TopBar/TopBar.module.scss
+++ b/src/components/layout/TopBar/TopBar.module.scss
@@ -40,3 +40,53 @@
     }
   }
 }
+
+@media (max-width: 767px) {
+  .root {
+    
+    .topOptions {
+      display: flex;
+      flex: 7;
+    }
+
+    .topMenu {
+      display: flex;
+      flex: 5;
+      
+      ul li {
+        margin-left: 1.3rem;
+      }
+    }
+
+    .topOptions, .topMenu {
+      padding: 0;
+    }
+
+    .topOptions ul li {
+      margin-right: 0.1rem;
+  
+      .icon {
+        margin-left: 0;
+      }
+    }
+  
+    .topMenu ul li a a { 
+      display: none;     
+    }
+  }
+}
+
+@media (min-width:768px) {
+  .root {
+    
+    .topOptions {
+      display: flex;
+      flex: 6;
+    }
+
+    .topMenu {
+      display: flex;
+      flex: 6;
+    }
+  }
+}

--- a/src/components/layout/TopBar/TopBar.module.scss
+++ b/src/components/layout/TopBar/TopBar.module.scss
@@ -47,6 +47,10 @@
     .topOptions {
       display: flex;
       flex: 8;
+      
+      ul li {
+        margin-left: 12px;
+      }
     }
 
     .topMenu {

--- a/src/components/layout/TopBar/TopBar.module.scss
+++ b/src/components/layout/TopBar/TopBar.module.scss
@@ -75,18 +75,3 @@
     }
   }
 }
-
-@media (min-width:768px) {
-  .root {
-    
-    .topOptions {
-      display: flex;
-      flex: 6;
-    }
-
-    .topMenu {
-      display: flex;
-      flex: 6;
-    }
-  }
-}

--- a/src/components/layout/TopBar/TopBar.module.scss
+++ b/src/components/layout/TopBar/TopBar.module.scss
@@ -46,12 +46,12 @@
     
     .topOptions {
       display: flex;
-      flex: 7;
+      flex: 8;
     }
 
     .topMenu {
       display: flex;
-      flex: 5;
+      flex: 4;
       
       ul li {
         margin-left: 1.3rem;


### PR DESCRIPTION
- Section "TopBar" and "CompanyClaim" have no RWD. It must be corrected for mobiles - only icons for "Login" and "Register", without text. Dropdowns on the left should look as on desktop. Logo ("Bazar online shopping") should be on the left, the basket on the right and as high as the logo. Under the basket must be the icon with phone number, text of which can be decreased to 14px.
- In TopBar.module.scss:
  -- I`ve added @media for mobiles and deleted left margin for icon dropdowns and made smaller right margin for dropdowns, so they look the same as for desktop. I`ve input none display for text of TopMenu icons. Now there are only icons for mobiles. TopOptions and TopMenu have got flex display and for TopMenu I`ve added smaller left margin for icons, so they fit in one row.
- In TopBar.js:
  -- I wrapped text of icons ("Login" and "Register") in "a href" element.
- In CompanyClaim.module.scss:
  -- Element with class phoneNumberOnMobiles has display none for larger than mobiles devices.
  -- Element with class phoneNumber has display none for mobiles.
  -- Element with class phoneNumberOnMobiles is visible and on the right side of banner, with smaller font (14px).
- In CompanyClaim.js:
  -- I`ve added div with style phoneNumberOnMobiles. It will be hidden on larger than mobile devices.
  -- I`ve wrapped cart element and phoneNumberOnMobiles element in one div.