### PR TITLE
WDP200802-20

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import store from './redux/store';
 import './styles/bootstrap.scss';
 import './styles/global.scss';
 
-import MainLayout from './components/layout/MainLayout/MainLayout';
+import MainLayout from './components/layout/MainLayout/MainLayoutContainer';
 import Homepage from './components/views/Homepage/Homepage';
 import ProductList from './components/views/ProductList/ProductList';
 import ProductPage from './components/views/ProductPage/ProductPage';

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -19,11 +19,22 @@ class NewFurniture extends React.Component {
   }
 
   render() {
-    const { categories, products } = this.props;
+    const { categories, products, deviceName } = this.props;
     const { activeCategory, activePage } = this.state;
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
-    const pagesCount = Math.ceil(categoryProducts.length / 8);
+
+    let productsPerPage = 1;
+    if (deviceName == 'mobile') {
+      productsPerPage = 1;
+    } else if (deviceName == 'tablet') {
+      productsPerPage = 2;
+    } else if (deviceName == 'desktop') {
+      productsPerPage = 8;
+    }
+    console.log('productsPerPage:', productsPerPage);
+
+    const pagesCount = Math.ceil(categoryProducts.length / productsPerPage);
 
     const dots = [];
     for (let i = 0; i < pagesCount; i++) {
@@ -67,11 +78,13 @@ class NewFurniture extends React.Component {
             </div>
           </div>
           <div className='row'>
-            {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <Col xs={12} md={6} lg={3} key={item.id} className='col-3'>
-                <ProductBox {...item} />
-              </Col>
-            ))}
+            {categoryProducts
+              .slice(activePage * productsPerPage, (activePage + 1) * productsPerPage)
+              .map(item => (
+                <Col sm={12} md={6} lg={3} key={item.id} className='col-3'>
+                  <ProductBox {...item} />
+                </Col>
+              ))}
           </div>
         </div>
       </div>
@@ -81,6 +94,7 @@ class NewFurniture extends React.Component {
 
 NewFurniture.propTypes = {
   children: PropTypes.node,
+  deviceName: PropTypes.string,
   categories: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -1,6 +1,7 @@
 @import "../../../styles/settings.scss";
 
 .root {
+  width: 100%;
   .panelBar {
     margin-bottom: 30px;
     position: relative;
@@ -95,6 +96,70 @@
             }
           }
         }
+      }
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .root {
+    .panelBar {
+      .heading {
+        margin: 0 0 92px 6px;
+        h3 {
+          font-size: 12px;
+        }
+      }
+      .dots {
+        margin: 52px 24px 0 0;
+      }
+      .menu {
+        margin: 0 6px 92px 0;    
+      }
+      .menu ul li {
+        margin: 0 0.2rem;
+        a {
+          font-size: 12px;
+          margin-bottom: 8px;
+          &.active,
+              &:hover {
+                &::before {
+                  margin-bottom: -8px;
+                }
+              }
+        }
+      }
+          
+      .dots ul {
+        text-align: center;
+      }
+      .dots ul li a {
+        width: 16px;
+        height: 16px;
+        border-radius: 10px;
+      }
+    }
+  }
+}
+
+@media (min-width: 768px) and (max-width: 991px) {
+  .root {
+    .panelBar {
+      .menu {
+        margin: 0 8px 44px 0;
+        padding-left: 24px;
+      }
+      .heading {
+        margin: 0 0 44px 8px;
+      }
+      .dots {
+        margin: 40px 72px 0 0;
+      }
+      .dots ul li a {
+        width: 24px;
+        height: 24px;
+        border-radius: 14px;
+        margin: 0 8px;
       }
     }
   }

--- a/src/components/features/NewFurniture/NewFurnitureContainer.js
+++ b/src/components/features/NewFurniture/NewFurnitureContainer.js
@@ -1,13 +1,13 @@
 import { connect } from 'react-redux';
-
 import NewFurniture from './NewFurniture';
-
 import { getAll } from '../../../redux/categoriesRedux.js';
 import { getNew } from '../../../redux/productsRedux.js';
+import { getDeviceName } from '../../../redux/deviceNameRedux.js';
 
 const mapStateToProps = state => ({
   categories: getAll(state),
   products: getNew(state),
+  deviceName: getDeviceName(state),
 });
 
 export default connect(mapStateToProps)(NewFurniture);

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -5,36 +5,33 @@ import Footer from '../Footer/Footer';
 
 export function get_window_width() {
   let window_width = document.documentElement.clientWidth;
-  console.log('window_width: ', window_width);
   return window_width;
 }
-window.addEventListener('resize', get_window_width);
 
-export function handleTest() {
-  console.log('test: ');
+class MainLayout extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    addWindowWidth: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+    this.props.addWindowWidth(get_window_width()); //when I start the app.
+    window.addEventListener('resize', () =>
+      this.props.addWindowWidth(get_window_width())
+    ); //when I resize the app`s window.
+  }
+
+  render() {
+    const { children } = this.props;
+    return (
+      <div>
+        <Header />
+        {children}
+        <Footer />
+      </div>
+    );
+  }
 }
-
-export function handleWidth(window_width) {
-  this.props.addWindowWidth(window_width);
-}
-
-const MainLayout = ({ children, deviceName, addWindowWidth }) => (
-  <div onClick={() => addWindowWidth(get_window_width())}>
-    <Header />
-    {children}
-    <Footer />
-  </div>
-);
-
-MainLayout.propTypes = {
-  children: PropTypes.node,
-  addWindowWidth: PropTypes.func,
-  deviceName: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string,
-      mode: PropTypes.string,
-    })
-  ),
-};
 
 export default MainLayout;

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -1,11 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
 
-const MainLayout = ({ children }) => (
-  <div>
+export function get_window_width() {
+  let window_width = document.documentElement.clientWidth;
+  console.log('window_width: ', window_width);
+  return window_width;
+}
+window.addEventListener('resize', get_window_width);
+
+export function handleTest() {
+  console.log('test: ');
+}
+
+export function handleWidth(window_width) {
+  this.props.addWindowWidth(window_width);
+}
+
+const MainLayout = ({ children, deviceName, addWindowWidth }) => (
+  <div onClick={() => addWindowWidth(get_window_width())}>
     <Header />
     {children}
     <Footer />
@@ -14,6 +28,13 @@ const MainLayout = ({ children }) => (
 
 MainLayout.propTypes = {
   children: PropTypes.node,
+  addWindowWidth: PropTypes.func,
+  deviceName: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      mode: PropTypes.string,
+    })
+  ),
 };
 
 export default MainLayout;

--- a/src/components/layout/MainLayout/MainLayoutContainer.js
+++ b/src/components/layout/MainLayout/MainLayoutContainer.js
@@ -1,18 +1,13 @@
 import { connect } from 'react-redux';
 import MainLayout from './MainLayout';
-import { getAll, addWindowWidth } from '../../../redux/mainLayoutRedux.js';
+import { getDeviceName, addWindowWidth } from '../../../redux/deviceNameRedux.js';
 
 const mapStateToProps = state => ({
-  deviceName: getAll(state),
+  deviceName: getDeviceName(state),
 });
 
 const mapDispatchToProps = dispatch => ({
-  addWindowWidth: window_width => dispatch(addWindowWidth(spy(window_width))),
+  addWindowWidth: window_width => dispatch(addWindowWidth(window_width)),
 });
-
-export function spy(gggggg) {
-  console.log('Container: ', gggggg);
-  return gggggg;
-}
 
 export default connect(mapStateToProps, mapDispatchToProps)(MainLayout);

--- a/src/components/layout/MainLayout/MainLayoutContainer.js
+++ b/src/components/layout/MainLayout/MainLayoutContainer.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import MainLayout from './MainLayout';
+import { getAll, addWindowWidth } from '../../../redux/mainLayoutRedux.js';
+
+const mapStateToProps = state => ({
+  deviceName: getAll(state),
+});
+
+const mapDispatchToProps = dispatch => ({
+  addWindowWidth: window_width => dispatch(addWindowWidth(spy(window_width))),
+});
+
+export function spy(gggggg) {
+  console.log('Container: ', gggggg);
+  return gggggg;
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MainLayout);

--- a/src/redux/deviceNameRedux.js
+++ b/src/redux/deviceNameRedux.js
@@ -1,7 +1,5 @@
 /* selectors */
-export const getAll = ({ deviceName }) => deviceName;
-export const getCount = ({ deviceName }) => deviceName.length;
-
+export const getDeviceName = ({ deviceName }) => deviceName;
 // action name creator
 const reducerName = 'deviceName';
 const createActionName = name => `app/${reducerName}/${name}`;
@@ -15,17 +13,17 @@ export default function reducer(statePart = [], action = {}) {
   switch (action.type) {
     case ADD_WINDOW_WIDTH: {
       console.log('action.payload', action.payload);
-      console.log('statePart', statePart);
+      console.log('oldStatePart', statePart);
 
       let screenMode = '';
-      if (action.payload < 480) {
+      if (action.payload < 768) {
         screenMode = 'mobile';
-      } else if (action.payload < 768) {
+      } else if (action.payload < 992) {
         screenMode = 'tablet';
       } else {
         screenMode = 'desktop';
       }
-
+      console.log('newStatePart', screenMode);
       return screenMode;
     }
     default:

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -1,5 +1,5 @@
 const initialState = {
-  deviceName: 'desktop',
+  deviceName: '',
   categories: [
     { id: 'bed', name: 'Bed' },
     { id: 'chair', name: 'Chair' },

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -1,4 +1,5 @@
 const initialState = {
+  deviceName: 'desktop',
   categories: [
     { id: 'bed', name: 'Bed' },
     { id: 'chair', name: 'Chair' },

--- a/src/redux/mainLayoutRedux.js
+++ b/src/redux/mainLayoutRedux.js
@@ -1,0 +1,34 @@
+/* selectors */
+export const getAll = ({ deviceName }) => deviceName;
+export const getCount = ({ deviceName }) => deviceName.length;
+
+// action name creator
+const reducerName = 'deviceName';
+const createActionName = name => `app/${reducerName}/${name}`;
+// action types
+export const ADD_WINDOW_WIDTH = createActionName('ADD_WINDOW_WIDTH');
+// action creatos
+export const addWindowWidth = payload => ({ payload, type: ADD_WINDOW_WIDTH });
+
+/* reducer */
+export default function reducer(statePart = [], action = {}) {
+  switch (action.type) {
+    case ADD_WINDOW_WIDTH: {
+      console.log('action.payload', action.payload);
+      console.log('statePart', statePart);
+
+      let screenMode = '';
+      if (action.payload < 480) {
+        screenMode = 'mobile';
+      } else if (action.payload < 768) {
+        screenMode = 'tablet';
+      } else {
+        screenMode = 'desktop';
+      }
+
+      return screenMode;
+    }
+    default:
+      return statePart;
+  }
+}

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -5,6 +5,7 @@ import cartReducer from './cartRedux';
 import categoriesReducer from './categoriesRedux';
 import productsReducer from './productsRedux';
 import brandsReducer from './brandsRedux';
+import mainLayoutReducer from './mainLayoutRedux';
 
 // define reducers
 const reducers = {
@@ -12,6 +13,7 @@ const reducers = {
   categories: categoriesReducer,
   products: productsReducer,
   brands: brandsReducer,
+  deviceName: mainLayoutReducer,
 };
 
 // add blank reducers for initial state properties without reducers

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,11 +1,10 @@
 import { combineReducers, createStore } from 'redux';
 import initialState from './initialState';
-
 import cartReducer from './cartRedux';
 import categoriesReducer from './categoriesRedux';
 import productsReducer from './productsRedux';
 import brandsReducer from './brandsRedux';
-import mainLayoutReducer from './mainLayoutRedux';
+import deviceNameReducer from './deviceNameRedux';
 
 // define reducers
 const reducers = {
@@ -13,7 +12,7 @@ const reducers = {
   categories: categoriesReducer,
   products: productsReducer,
   brands: brandsReducer,
-  deviceName: mainLayoutReducer,
+  deviceName: deviceNameReducer,
 };
 
 // add blank reducers for initial state properties without reducers


### PR DESCRIPTION
description:
- When the site is run, MainLayout must activate listener for viewport width changes and - on this basis - it must set current device mode (desktop, tablet or mobile) in aplication`s state. It must be used at first in section "New furniture" - there are supposed to be visible 8 products on desktop, 2 in a row on tablets and 1 in a row on mobile (as in task WDP200802-17).

- I`ve added file deviceNameRedux.js in src\redux.
- I`ve changed store.js and initialState.js.
- I`ve created MainLayoutContainer.js and imported in App.js.
- I`ve changed MainLayout.js, NewFurniture.js and NewFurnitureContainer.js and NewFurniture.module.scss.